### PR TITLE
Updated EX4 instructions of the starknet messaging bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Write and deploy a contract on L1 that *sends* messages to L2.
   - You can name your function however you like, since you provide the function selector as a parameter on L1
 - Deploy your contract on L2
 - Call [`ex4`](contracts/L1/Evaluator.sol#L60) of *L1 Evaluator* to send the random value out to your L2 contract
+- Submit your L2 contract address by calling [`submit_exercise`](contracts/Evaluator.cairo#L166) of *L2 Evaluator*
 - Call [`ex4_b`](contracts/Evaluator.cairo#L266) of *L2 Evaluator* that will check you completed your work correctly and distribute your points
 
 ## Annex - Useful tools and ressources


### PR DESCRIPTION
Whilst attempting EX4 of the starknet messaging bridge exercises, i had a lot of troubles with calling ex4b to validate my solution.

It took me a while of debugging to realize i was meant to submit my L2 contract using the submit_exercise of the L2 Evaluator before i could call the ex4b, and this was because there was no instruction to do this.

I updated the README, to include this instruction for future persons who might make such dumb mistakes like i did.